### PR TITLE
Fix log exclusion in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 config.php
-log/!.placeholder
+
+log
+!log/.placeholder


### PR DESCRIPTION
We need to ignore all of `log` before un-ignoring `log/.placeholder`.